### PR TITLE
OpenCV 3 Support

### DIFF
--- a/readme.rst
+++ b/readme.rst
@@ -81,8 +81,6 @@ Operation                           Pillow               Wand                 Op
 ``save_as_gif(file)``               ✓                    ✓
 ``has_alpha()``                     ✓                    ✓                    ✓*
 ``has_animation()``                 ✓*                   ✓                    ✓*
-``get_pillow_image()``              ✓
-``get_wand_image()``                                     ✓
 ``detect_features()``                                                         ✓
 ``detect_faces(cascade_filename)``                                            ✓
 =================================== ==================== ==================== ====================

--- a/readme.rst
+++ b/readme.rst
@@ -72,19 +72,19 @@ Available operations
 =================================== ==================== ==================== ====================
 Operation                           Pillow               Wand                 OpenCV
 =================================== ==================== ==================== ====================
-``get_size()``                      ✓                    ✓
+``get_size()``                      ✓                    ✓                    ✓
 ``resize(size)``                    ✓                    ✓
 ``crop(rect)``                      ✓                    ✓
 ``auto_orient()``                   ✓                    ✓
 ``save_as_jpeg(file, quality)``     ✓                    ✓
 ``save_as_png(file)``               ✓                    ✓
 ``save_as_gif(file)``               ✓                    ✓
-``has_alpha()``                     ✓                    ✓
-``has_animation()``                 ✓*                   ✓
+``has_alpha()``                     ✓                    ✓                    ✓*
+``has_animation()``                 ✓*                   ✓                    ✓*
 ``get_pillow_image()``              ✓
 ``get_wand_image()``                                     ✓
 ``detect_features()``                                                         ✓
 ``detect_faces(cascade_filename)``                                            ✓
 =================================== ==================== ==================== ====================
 
-\* Always returns ``False`` as Pillow doesn't support animation
+\* Always returns ``False``


### PR DESCRIPTION
This pull request adds support for OpenCV 3.  It will fall back to the old cv api if cv2 is not available.
